### PR TITLE
ユーザー情報編集機能実装の修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,10 @@ class UsersController < ApplicationController
 
   def update
     @user = User.find(params[:id])
-    if @user.update(update_params)
+    if @user.update(update_paramas)
+      redirect_to user_path(@user.id)
+    elsif @user.update_without_current_password(no_pass_update_params)
+      @user.update(no_pass_update_params)
       redirect_to user_path(@user.id)
     else
       render :edit
@@ -19,8 +22,12 @@ class UsersController < ApplicationController
   end
 
   private
-  def update_params
+  def no_pass_update_params
     params.require(:user).permit(:image, :name, :text)
+  end
+  
+  def update_paramas
+    params.require(:user).permit(:image, :name, :email, :password, :text)
   end
 
   def move_to_index

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,14 +2,27 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
   
   validates :password, presence: true, on: :create, format: { with: PASSWORD_REGEX, message: 'は半角英数字6文字以上で入力してください' }
   validates :name, presence: true
+  validates :email, presence: true
   
   has_many         :books
   has_one_attached :image
+
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+
+    if params[:password].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation) if params[:password_confirmation].blank?
+    end
+
+    clean_up_passwords
+    update_attributes(params, *options)
+  end
 
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -20,7 +20,7 @@
             <li class="left-content"><%= link_to "見つける", "#", class:"content-btn" %></li>
           <ul>
         </div>
-        <% unless current_user.id  == @book.user.id %>
+        <% unless user_signed_in? && current_user.id  == @book.user.id %>
         <div class="post-user-account">
           <%= link_to "#{@book.user.name}", user_path(@book.user.id), class:"user-account" %>
           <span>さんの投稿</span>
@@ -30,7 +30,7 @@
     </div>
 
     <div class="posts-index">
-      <% if current_user.id  == @book.user.id %>
+      <% if user_signed_in? && current_user.id  == @book.user.id %>
         <div class="create-content">
           <a ><%= link_to 'アウトプット', new_book_post_path(@book.id), class:"add-btn-post" %></a>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: 'registrations' }
   root to:  'books#index'
   resources :books do
     resources :posts, only: [:new, :create, :show, :edit, :update, :destroy]


### PR DESCRIPTION
#What
ユーザー情報を編集する際に、パスワードの変更・入力を任意にする機能の実装

#Why
ユーザー名やプロフィール画像を変えたいときに、パスワードを入力する手間を省くため。