### PR TITLE
Basic認証を導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,13 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   before_action :config_permitted_parameters, if: :devise_controller?
 
   private
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 
   def config_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])


### PR DESCRIPTION
#What
Basic認証を導入

#Why
認証済みユーザーのみの利用に限定するため